### PR TITLE
Calling back with the underlying request error on failures

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -42,8 +42,8 @@ Client.prototype.request = function(options, cb) {
   };
 
   request(requestOptions, function(err, response, body) {
-    if (err) {
-      return cb(err);
+    if(err || !response) {
+      return cb(err || new Error('node-librato-metrics: No response received!'));
     }
     var code = response.statusCode || '';
     if (!err && ((body && body.errors) || code > 399)) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -42,9 +42,9 @@ Client.prototype.request = function(options, cb) {
   };
 
   request(requestOptions, function(err, response, body) {
-    if(!response) {
-      return cb(new Error('node-librato-metrics: No response received!'));
-    }
+  	if (err) {
+  		return cb(err);
+  	}
     var code = response.statusCode || '';
     if (!err && ((body && body.errors) || code > 399)) {
       err = new Error(

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -42,9 +42,9 @@ Client.prototype.request = function(options, cb) {
   };
 
   request(requestOptions, function(err, response, body) {
-  	if (err) {
-  		return cb(err);
-  	}
+    if (err) {
+      return cb(err);
+    }
     var code = response.statusCode || '';
     if (!err && ((body && body.errors) || code > 399)) {
       err = new Error(


### PR DESCRIPTION
Hi, thanks for creating this library!  I'm suggesting a small error-handling change... right now, if the request library calls back with an error instead of with a request object, it hits the "no response received!" branch, which returns a generic message instead of the specific failure (which might not be on the Librato end -- could be a network connectivity issue, etc.)  request always calls back with either an error or a response, so the check for a missing response isn't really necessary if we check for an error.